### PR TITLE
Make filter-from-backend return a lazy seq

### DIFF
--- a/src/archive_bolt/backends/core.clj
+++ b/src/archive_bolt/backends/core.clj
@@ -29,5 +29,5 @@
   (throw (Exception. (str "Backend not found for " backend))))
 
 (defmethod filter-from-backend :s3
-  [_ conf location & [pred-fn]]
-  (s3/filter-from-backend conf location {:filter-fn pred-fn}))
+  [_ conf location & [opts]]
+  (s3/filter-from-backend conf location opts))

--- a/src/archive_bolt/backends/core.clj
+++ b/src/archive_bolt/backends/core.clj
@@ -30,4 +30,4 @@
 
 (defmethod filter-from-backend :s3
   [_ conf location & [pred-fn]]
-  (s3/filter-from-backend conf location pred-fn))
+  (s3/filter-from-backend conf location {:filter-fn pred-fn}))

--- a/src/archive_bolt/backends/s3.clj
+++ b/src/archive_bolt/backends/s3.clj
@@ -1,5 +1,5 @@
 (ns archive-bolt.backends.s3
-  (:require [backtype.storm.log :as storm] 
+  (:require [backtype.storm.log :as storm]
             [amazonica.aws.s3 :as s3]
             [archive-bolt.utils :refer [get-or-throw]]
             [cheshire.core :as json]
@@ -23,14 +23,14 @@
     (str "s3://" bucket "/" location)))
 
 (defn safe-put
-  "Attempt to PUT the file to s3 returns full s3 path when successful or 
+  "Attempt to PUT the file to s3 returns full s3 path when successful or
    nil if unsuccessful. Retries on failure up to max-retries times."
   [creds bucket location content
    & {:keys [retry-count max-retries wait-time]
       :or {retry-count 0, max-retries 10 wait-time 1000}}]
   ;; Store the content and return the location
   (try
-    (put-object creds bucket location content) 
+    (put-object creds bucket location content)
     (catch Exception e
       (do (Thread/sleep wait-time)
           (storm/log-error e " Failed to store in s3. "
@@ -68,7 +68,7 @@
    :value (try (-> (s3/get-object credentials
                                   :bucket-name bucket-name
                                   :key key)
-                   :input-stream 
+                   :input-stream
                    slurp
                    (json/parse-string true))
                (catch Exception e
@@ -76,29 +76,39 @@
                   (format "Failed to get bucket: %s, key: %s, error: %s "
                           bucket-name key e))))})
 
+;; TODO add an option to set the pagination value and lazy concat
+;; results together should give enough control to avoid out of memory issues
+
 (defn filter-from-backend
   "Search s3 for keys at the given location. Take the list of keys and look
    them up. If the results are paginated, recur until all results are returned.
-   Results are paginated by 1,000 keys as per the S3 API docs. Results keys are 
-   filtered by filter-fn. Returns a collection of results."
-  [conf location & [filter-fn accum marker]]
-  (let [creds (mk-credentials conf)
-        ;; For backwards compatibility look for the old key as fallback
-        bucket-name (or (get conf "ARCHIVE_READ_S3_BUCKET")
-                        (get conf "S3_BUCKET")
-                        (throw (Exception. "Missing config field ARCHIVE_READ_S3_BUCKET")))
-        ;; Search s3 for all keys at the location
-        search-results (s3/list-objects creds
-                                        :bucket-name bucket-name
-                                        :prefix location
-                                        :marker marker)
-        ;; Grab the keys and optionally filter them
-        keys ((or filter-fn identity) (get-keys-from-results search-results))
-        values (pmap #(lookup-key creds bucket-name location %) keys)
-        result (concat accum values)]
-    ;; If there is a next marker then we should recur
-    (if-let [next-marker (:next-marker search-results)] 
-      ;; NOTE optional args must be in a vector when using recur
-      (do (storm/log-message "Paging archive results at " location)
-          (recur conf location [filter-fn result next-marker]))
-      result)))
+   Results are paginated by 1,000 keys as per the S3 API docs. Results keys are
+  filtered by filter-fn. Returns a lazy seq of results."
+  ([conf location]
+   (filter-from-backend conf location nil {}))
+  ([conf location {:keys [filter-fn marker] :as opts}]
+   (filter-from-backend conf location nil opts))
+  ([conf location accum {:keys [filter-fn marker] :as opts}]
+   (let [creds (mk-credentials conf)
+         ;; For backwards compatibility look for the old key as fallback
+         bucket-name (or (get conf "ARCHIVE_READ_S3_BUCKET")
+                         (get conf "S3_BUCKET")
+                         (throw (Exception. "Missing config field ARCHIVE_READ_S3_BUCKET")))
+         ;; Search s3 for all keys at the location
+         search-results (s3/list-objects creds
+                                         :bucket-name bucket-name
+                                         :prefix location
+                                         :marker marker)
+         ;; Grab the keys and optionally filter them
+         keys ((or filter-fn identity) (get-keys-from-results search-results))
+         values (pmap #(lookup-key creds bucket-name location %) keys)]
+     ;; If there is a next marker then we should recur
+     (if-let [next-marker (:next-marker search-results)]
+       (do (storm/log-message "Paging archive results at " location)
+           (lazy-cat accum
+                     (filter-from-backend conf
+                                          location
+                                          (lazy-cat accum values)
+                                          {:filter-fn filter-fn
+                                           :marker next-marker})))
+       (lazy-cat accum values)))))

--- a/src/archive_bolt/backends/s3.clj
+++ b/src/archive_bolt/backends/s3.clj
@@ -105,10 +105,6 @@
      ;; If there is a next marker then we should recur
      (if-let [next-marker (:next-marker search-results)]
        (do (storm/log-message "Paging archive results at " location)
-           (lazy-cat accum
-                     (filter-from-backend conf
-                                          location
-                                          (lazy-cat accum values)
-                                          {:filter-fn filter-fn
-                                           :marker next-marker})))
+           (recur conf location (lazy-cat accum values) {:filter-fn filter-fn
+                                                         :marker next-marker}))
        (lazy-cat accum values)))))

--- a/src/archive_bolt/backends/s3.clj
+++ b/src/archive_bolt/backends/s3.clj
@@ -87,7 +87,8 @@
   ([conf location]
    (filter-from-backend conf location nil {}))
   ([conf location {:keys [filter-fn marker] :as opts}]
-   (let [creds (mk-credentials conf)
+   (lazy-seq
+    (let [creds (mk-credentials conf)
          ;; For backwards compatibility look for the old key as fallback
          bucket-name (or (get conf "ARCHIVE_READ_S3_BUCKET")
                          (get conf "S3_BUCKET")
@@ -104,6 +105,6 @@
      (if-let [next-marker (:next-marker search-results)]
        (do (storm/log-message "Paging archive results at " location)
            (concat values
-                   (lazy-seq (filter-from-backend conf location {:filter-fn filter-fn
-                                                                 :marker next-marker}))))
-       values))))
+                   (filter-from-backend conf location {:filter-fn filter-fn
+                                                       :marker next-marker})))
+       values)))))

--- a/src/archive_bolt/storm.clj
+++ b/src/archive_bolt/storm.clj
@@ -32,8 +32,7 @@
   [conf collector tuple & [filter-fn]]
   (let [{:keys [meta backend location]} tuple
         filter-fn (or filter-fn identity)
-        results (take-while (comp not nil?)
-                            (filter-from-backend backend conf location {:filter-fn filter-fn}))]
+        results (filter-from-backend backend conf location {:filter-fn filter-fn})]
     (if (seq results)
       (emit-bolt! collector [meta results] :anchor tuple)
       (log-debug (format "No results returned from %s backend at %s"
@@ -61,6 +60,6 @@
     [tuple]
     (let [{:keys [meta backend location]} tuple
           results (filter-from-backend backend conf location)]
-      (doseq [r (partition-all chunk-n (take-while (comp not nil?) results))]
+      (doseq [r (partition-all chunk-n results)]
         (emit-bolt! collector [meta results] :anchor tuple))
       (ack! collector tuple)))))

--- a/src/archive_bolt/storm.clj
+++ b/src/archive_bolt/storm.clj
@@ -1,6 +1,6 @@
 (ns archive-bolt.storm
   (:require [backtype.storm.clojure :refer [defbolt bolt emit-bolt! ack! fail!]]
-            [backtype.storm.log :refer [log-debug log-warn]]
+            [backtype.storm.log :refer [log-debug log-message log-warn]]
             [archive-bolt.backends.core :refer [store filter-from-backend]]
             [archive-bolt.fields :as fields])
   (:gen-class))
@@ -35,8 +35,8 @@
         results (filter-from-backend backend conf location {:filter-fn filter-fn})]
     (if (seq results)
       (emit-bolt! collector [meta results] :anchor tuple)
-      (log-debug (format "No results returned from %s backend at %s"
-                         backend location)))
+      (log-message (format "No results returned from %s backend at %s"
+                           backend location)))
     (ack! collector tuple)))
 
 (defbolt archive-read fields/archive-read-output-fields

--- a/test/archive_bolt/backends/s3_test.clj
+++ b/test/archive_bolt/backends/s3_test.clj
@@ -71,7 +71,7 @@
            (backend/filter-from-backend :s3
                                         (get-test-conf)
                                         test-location
-                                        (fn [coll] (set coll)))))))
+                                        {:filter-fn (fn [coll] (set coll))})))))
 
 (defn mock-list-objects
   [_ & {:keys [bucket-name prefix marker]}]

--- a/test/archive_bolt/backends/s3_test.clj
+++ b/test/archive_bolt/backends/s3_test.clj
@@ -56,8 +56,7 @@
                      :full-path test-key
                      :file-name test-file-name}
               :value test-content}]
-            (take-while (comp not nil?)
-                        (backend/filter-from-backend :s3 (get-test-conf) test-location))))))
+            (backend/filter-from-backend :s3 (get-test-conf) test-location)))))
 
 (deftest test-filter-from-backend-no-results)
   #(is (= (backend/filter-from-backend :s3 (get-test-conf) test-location)
@@ -68,12 +67,11 @@
                                   {:object-summaries [{:key "foo"} {:key "foo"}]
                                    :next-marker nil})
                 s3-backend/lookup-key (fn [_ _ _ k] {k k})]
-    (is (= (take-while (comp not nil?)
-                       (backend/filter-from-backend :s3
-                                                    (get-test-conf)
-                                                    test-location
-                                                    (fn [coll] (set coll))))
-           [{"foo" "foo"}]))))
+    (is (= [{"foo" "foo"}]
+           (backend/filter-from-backend :s3
+                                        (get-test-conf)
+                                        test-location
+                                        (fn [coll] (set coll)))))))
 
 (defn mock-list-objects
   [_ & {:keys [bucket-name prefix marker]}]
@@ -88,5 +86,4 @@
   (with-redefs [s3/list-objects mock-list-objects
                 s3-backend/lookup-key (fn [_ _ _ k] k)]
     (is (= ["foo" "bar" "baz"]
-           (take-while (comp not nil?)
-                       (backend/filter-from-backend :s3 (get-test-conf) test-location))))))
+           (backend/filter-from-backend :s3 (get-test-conf) test-location)))))


### PR DESCRIPTION
## About

This is meant to reduce the memory overhead when there are many keys in
a given location when trying to use filter-from-backend. Actual calls to
s3 are lazy and only perform IO as the sequence is consumed.
## Tests

```
AWS_ACCESS_KEY_ID=<your api key> AWS_SECRET_ACCESS_KEY=<your api secret> lein test
```
## Reviewers

@jeremyheiler @nathants 
